### PR TITLE
Fix depth image casting error

### DIFF
--- a/mmfi_lib/mmfi.py
+++ b/mmfi_lib/mmfi.py
@@ -210,8 +210,8 @@ class MMFi_Dataset(Dataset):
             data = np.array(data)
         elif mod == 'depth':
             for img in sorted(glob.glob(os.path.join(dir, "frame*.png"))):
-                _cv_img = cv2.imread(img, cv2.IMREAD_UNCHANGED)  # Default depth value is 16-bit
-                _cv_img *= 0.001  # Convert unit to meter
+                # Default depth value is 16-bit, convert unit to meter
+                _cv_img = cv2.imread(img, cv2.IMREAD_UNCHANGED) * 0.001
                 data.append(_cv_img)
             data = np.array(data)
         elif mod == 'lidar':


### PR DESCRIPTION
Under data_unit `sequence` with modality `mmwave`, when the depth image convert the value to meter, it shows the following error:

```
  File "/mm-FI/mmfi_lib/mmfi.py", line 454, in read_dir
    _cv_img *= 0.001  # Convert unit to meter
numpy.core._exceptions._UFuncOutputCastingError:
Cannot cast ufunc 'multiply' output from dtype('float64') to dtype('uint16') with casting rule 'same_kind'
```

Fix by multipying the unit when reading the image, this also match how data_unit `frame` does.